### PR TITLE
Update clone_aws_params

### DIFF
--- a/admin_tasks/clone_aws_params.py
+++ b/admin_tasks/clone_aws_params.py
@@ -1,17 +1,23 @@
 """
 Clone parameters from one AWS dev account to another.
 
+Skips any parameters that already exist. Note that the script will attempt to
+    reformat any params and values before it copies, but may then skip if it
+    already exists.
+
 This is needed for before any thiscovery stack is deployed to AWS.
 
 secrets.py will need adding/updating
 .aws/credentials will need details of both the source and target accounts
 
 """
+
+import boto3
+
 import local.secrets  # sets env variables
 import local.dev_config as conf  # sets env variables
 
 from thiscovery_lib.utilities import namespace2profile
-import boto3
 
 
 def get_client(profile):
@@ -33,9 +39,9 @@ if __name__ == "__main__":
     paginator = source_client.get_paginator("get_parameters_by_path")
 
     for page in paginator.paginate(
-        Path=f"/{conf.SOURCE_ENV}/",  # SOURCE_ENV is e.g. dev-afs25, test-sem86, etc
-        WithDecryption=True,
-        Recursive=True,
+            Path=f"/{conf.SOURCE_ENV}/",  # SOURCE_ENV is e.g. dev-afs25, test-sem86, etc
+            WithDecryption=True,
+            Recursive=True,
     ):
         for param in page["Parameters"]:
             param_name = param["Name"]

--- a/admin_tasks/clone_aws_params.py
+++ b/admin_tasks/clone_aws_params.py
@@ -10,23 +10,25 @@ secrets.py will need adding/updating
 import local.secrets  # sets env variables
 import local.dev_config as conf  # sets env variables
 
-
+from thiscovery_lib.utilities import namespace2profile
 import boto3
 
 
-def get_client(profile_name):
+def get_client(profile):
     """
-    :param profile_name: A profile name in your AWS credentials file
+    :param profile: profile name, eg test-sem86
     :return:
     """
+
+    profile_name = namespace2profile('/' + profile + '/')
     session = boto3.Session(profile_name=profile_name)
     return session.client("ssm", region_name="eu-west-1")
 
 
 if __name__ == "__main__":
 
-    source_client = get_client(conf.SOURCE_PROFILE)
-    target_client = get_client(conf.TARGET_PROFILE)
+    source_client = get_client(conf.SOURCE_ENV)
+    target_client = get_client(conf.TARGET_ENV)
 
     paginator = source_client.get_paginator("get_parameters_by_path")
 


### PR DESCRIPTION
This needed extra redundant stuff in config that could easily be deduced from the standard set of stuff we already have. So I've removed that and now use just the SOURCE_ENV and TARGET_ENV variables.

This also means the aws credentials file doens't need fiddling with beyond the usual pasting of up-to-date credntials. 