### PR TITLE
4871 Add custom capabilities to thiscovery command line tool

### DIFF
--- a/thiscovery_dev_tools/aws_deployer.py
+++ b/thiscovery_dev_tools/aws_deployer.py
@@ -215,7 +215,7 @@ class AwsDeployer:
                 "--s3-bucket",
                 os.environ["ARTIFACTS_BUCKET"],
                 "--capabilities",
-                "CAPABILITY_IAM",
+                "CAPABILITY_NAMED_IAM",
                 "--no-fail-on-empty-changeset",
                 "--stack-name",
                 f"{self.stack_name}-{self.environment}",

--- a/thiscovery_dev_tools/aws_deployer.py
+++ b/thiscovery_dev_tools/aws_deployer.py
@@ -200,7 +200,7 @@ class AwsDeployer:
             param_overrides_str += f"ParameterKey={k},ParameterValue={v} "
         return f'"{param_overrides_str.strip()}"'
 
-    def deploy(self, confirm_cf_changeset):
+    def deploy(self, confirm_cf_changeset, iam_capability_type="CAPABILITY_IAM"):
         self.logger.info("Starting deployment phase")
         deployment_method = os.environ.get("DEPLOYMENT_METHOD")
         if deployment_method == "github_actions":
@@ -215,7 +215,7 @@ class AwsDeployer:
                 "--s3-bucket",
                 os.environ["ARTIFACTS_BUCKET"],
                 "--capabilities",
-                "CAPABILITY_NAMED_IAM",
+                iam_capability_type,
                 "--no-fail-on-empty-changeset",
                 "--stack-name",
                 f"{self.stack_name}-{self.environment}",
@@ -344,7 +344,10 @@ class AwsDeployer:
             if self.stack_name != "thiscovery-core":
                 self.validate_template()
             self.build(kwargs.get("build_in_container", False))
-        self.deploy(kwargs.get("confirm_cf_changes", False))
+        self.deploy(
+            kwargs.get("confirm_cf_changes", False),
+            kwargs.get("iam_capability_type", "CAPABILITY_IAM"),
+        )
         self.log_deployment()
         if not kwargs.get("skip_slack_notification", False):
             self.slack_message()

--- a/thiscovery_dev_tools/command_line.py
+++ b/thiscovery_dev_tools/command_line.py
@@ -59,6 +59,13 @@ def main():
         metavar="stack_name",
         help="Name of stack being deployed",
     )
+    parser_deploy.add_argument(
+        "-o",
+        "--iam_capability_type",
+        help="capabilities type when running sam deploy. Use "
+             "CAPABILITY_NAMED_IAM for example."
+             "Defaults to CAPABILITY_IAM"
+    )
     parser_deploy.set_defaults(func=aws_deployer_deploy)
 
     args = parser.parse_args()


### PR DESCRIPTION
We have a command line tool that lets us run things like 

`thiscovery deploy thiscovery-core`

This tool is used in the CICD process. This PR adds to option of using a custom sam deploy capability:

`thiscovery deploy s3-to-sdhs --iam_capability_type CAPABILITY_NAMED_IAM`